### PR TITLE
Parse URLs using plistlib; supports URLs containing special chars

### DIFF
--- a/webloccer.py
+++ b/webloccer.py
@@ -18,7 +18,7 @@
 # webloccer.py
 # copyright (c) by Alexander Lehmann <afwlehmann@in.tum.de>
 
-import xml.parsers.expat, sys, os
+import plistlib, sys, os
 from PyQt4.QtCore import QCoreApplication
 from PyKDE4.kdecore import KToolInvocation
 
@@ -26,37 +26,18 @@ class WebLocParser(QCoreApplication):
 
     def __init__(self):
         super(QCoreApplication, self).__init__(sys.argv)
-
         self.reset()
          
     def parseAndOpen(self, fileName):
         try:
-            with open(fileName, 'r') as fIn:
-                self._p.ParseFile(fIn)
-                if self._url:
-                    KToolInvocation.invokeBrowser(self._url)
-                else:
-                    raise "Hell"
+	    plist = plistlib.readPlist(fileName)
+	    if 'URL' in plist:
+	        KToolInvocation.invokeBrowser(plist['URL'])
         except:
             sys.stderr.write("Invalid webloc file: %s\n" % fileName)
 
-    def _startElement(self, name, attrs):
-        self._insideURL = name.lower() == "string"
-
-    def _endElement(self, name):
-        self._insideURL = name.lower() == "string" and False
-
-    def _charData(self, data):
-        if self._insideURL:
-            self._url = data
-
     def reset(self):
-        self._insideURL = False
-        self._url = None
-        self._p = xml.parsers.expat.ParserCreate()
-        self._p.StartElementHandler = self._startElement
-        self._p.EndElementHandler = self._endElement
-        self._p.CharacterDataHandler = self._charData
+	pass
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:


### PR DESCRIPTION
Submitted by email 2015-07-09; just uses Python 2.6+ built-in plistlib (cross-platform) to parse OS X plists instead of scraping the field with the XML parser manually. No functional change.
